### PR TITLE
camera2: fix front camera orientation on HAL3

### DIFF
--- a/gemini/proprietary/etc/camera/msm8996_camera.xml
+++ b/gemini/proprietary/etc/camera/msm8996_camera.xml
@@ -143,7 +143,7 @@ LensInfo : Information of the lens present in the module.
     <ChromatixName>ov4688_chromatix</ChromatixName>
     <ModesSupported>1</ModesSupported>
     <Position>FRONT</Position>
-    <MountAngle>360</MountAngle>
+    <MountAngle>270</MountAngle>
     <CSIInfo>
       <CSIDCore>2</CSIDCore>
       <LaneMask>0x1F</LaneMask>
@@ -166,7 +166,7 @@ LensInfo : Information of the lens present in the module.
     <ChromatixName>ov4688_primax_chromatix</ChromatixName>
     <ModesSupported>1</ModesSupported>
     <Position>FRONT</Position>
-    <MountAngle>360</MountAngle>
+    <MountAngle>270</MountAngle>
     <CSIInfo>
       <CSIDCore>2</CSIDCore>
       <LaneMask>0x1F</LaneMask>


### PR DESCRIPTION
Fix front camera orientation on HAL3/API2 by using the value of 270 instead of 360 (rotation by kernel)